### PR TITLE
now checking distance between peaks

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -9,10 +9,11 @@ auth_key = "abc123"
 outdir = "storage"
 
 tmp_storage = {}
+tmp_count = 0
 
 @app.route(f"/api/v{api_version}/accel/reading", methods=["POST"])
 def reading():
-    global tmp_storage
+    global tmp_storage, tmp_count
     obj = request.json
     auth_key_submitted = obj.pop("authKey")
     seq = obj.pop("payload")
@@ -20,17 +21,33 @@ def reading():
         return jsonify({"status": "unauthorized"}), 401
 
     tmp_storage.update(seq)
-    print(len(tmp_storage))
+
+    # immediately count the number of steps in this chunk sent by the client
+    skips_count = find_skips(seq)
+    # also, keep "tmp_count" updated with the number of skips that we have
+    # currently (i.e. since the latest storage) sent the client
+    tmp_count += skips_count
+
+    print(len(tmp_storage)) # debug message (TODO: use logging)
 
     if len(tmp_storage) > 500:
         min_ts = min(tmp_storage.keys())
 
+        # now count the "correct" number of skips (i.e. on the entire "tmp_storage" buffer
+        # The result is then compared with "tmp_count" (the count that has been sent thus far)
+        # Only the delta is sent (to provide the correct count to the client)
+        skips_count = find_skips(tmp_storage) # "true" count
+
+        # now skips_count contains the "adjusting" value (i.e. the offset from what we
+        # previously told the client to the "correct" number. We send this offset so
+        # that the client has a valid estimate (can be positive or negative)
+        skips_count = skips_count - tmp_count 
+
         with open(os.path.join(outdir, f"{min_ts}.json"), "w") as f:
             json.dump(tmp_storage, f)
             tmp_storage = {}
+            tmp_count = 0 # reset count
 
-
-    skips_count = find_skips(seq)
     return jsonify({"status": "OK", "count": skips_count }), 200
     
 

--- a/server/peaks.py
+++ b/server/peaks.py
@@ -2,33 +2,42 @@ import numpy as np
 from scipy.signal import find_peaks
 
 
-def find_skips(readings):
+def pks(x):
     # max freq: 3 Hz. Sampling @ 25 Hz: 1 peak each 8 samples --> distance=8
     distance = 25//3
-    prominence = 500
+
+    prominence = 1000
+    p = find_peaks(x, distance=distance, prominence=prominence)[0]
+    # d is the distance between the i-th peak and
+    # the (i+1)-th. We do not have distance for the
+    # final peak (see below how we handle this)
+    d = p[1:] - p[:-1]
+
+    # jump frequency: ~1.5 - 3 Hz.
+    # @25 Hz sampling, we should expect
+    # between 8 and 15 samples between
+    # jumps. Peaks outside of this range
+    # are discarded
+    m1 = (d>=8)&(d<=15)
+
+    # the approach makes it so that we do not know
+    # the outcome for the final peak (it does not have
+    # a subsequent peak to compare it to). The adopted
+    # policy is that if the last but one is a peak, then
+    # also the last one is considered a peak
+    m2 = np.append(m1, m1[-1])
+    return p[m2]
+
+def find_skips(readings):
 
     xyz = [ v[1] for v in sorted(readings.items(), key=lambda x: x[0]) ]
     x = [ x for x,_,_ in xyz ]
     y = [ y for _,y,_ in xyz ]
     z = [ z for _,_,z in xyz ]
 
-    peaks_x, _ = find_peaks(x, distance=distance, prominence=prominence)
-    peaks_y, _ = find_peaks(y, distance=distance, prominence=prominence)
-    peaks_z, _ = find_peaks(z, distance=distance, prominence=prominence)
+    peaks_x = pks(x)
+    peaks_y = pks(y)
+    peaks_z = pks(z)
 
-    print(len(peaks_x), len(peaks_y), len(peaks_z))
     return int(round(np.mean([len(peaks_x), len(peaks_y), len(peaks_z)])))
-
-# debugging function: to be deleted
-def plot_peaks(x):
-    # max freq: 3 Hz. Sampling @ 25 Hz: 1 peak each 8 samples --> distance=8
-    distance = 25//3
-    prominence=500
-
-    xn = np.array(x)
-    plt.plot(xn)
-    peaks, _ = find_peaks(x, distance=distance, prominence=prominence)
-    print(len(peaks))
-
-    plt.scatter(peaks, xn[peaks], marker='x', color='r')
 


### PR DESCRIPTION
Addressing issue #6 

As already mentioned, there was no real need to change the peak finding function. 

The main changes here are:
- prominence from 500 to 1,000 (many FPs were occurring because of this)
- added a range of values in which peaks should be found: if two peaks are distant less than 8 samples or more than 15, they are not counted (the <= 8 threshold was already in place (distance=8 to find_peaks()), but not the >= 15. 

The results seem quite promising (x axis: sample #, y axis: accelerometer reading - in blue the signals, the red 'x's are the peaks identified now):

![immagine](https://user-images.githubusercontent.com/107715/108753143-a3b97b80-7544-11eb-88b9-bf5911a6529a.png)
^ for a full recording of peaks, there is no problem. 

![immagine](https://user-images.githubusercontent.com/107715/108753209-b92ea580-7544-11eb-9559-2d687f8bda4a.png)
^ for a recording with noise, the noise is now correctly ignored.